### PR TITLE
Changed return value of getEvent and value of event.light in case of saturation

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -385,10 +385,10 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
       break;
   }
 
-  /* Return 0 lux if the sensor is saturated */
+  /* Return 65536 lux if the sensor is saturated */
   if ((broadband > clipThreshold) || (ir > clipThreshold))
   {
-    return 0;
+    return 65536;
   }
 
   /* Get the correct scale depending on the intergration time */
@@ -476,6 +476,8 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
 /**************************************************************************/
 /*!
     @brief  Gets the most recent sensor event
+    returns true if sensor reading is between 0 and 65535 lux
+    returns false if sensor is saturated
 */
 /**************************************************************************/
 bool Adafruit_TSL2561_Unified::getEvent(sensors_event_t *event)
@@ -494,6 +496,9 @@ bool Adafruit_TSL2561_Unified::getEvent(sensors_event_t *event)
   getLuminosity(&broadband, &ir);
   event->light = calculateLux(broadband, ir);
   
+  if (event->light == 65536) {
+    return false;	
+  }
   return true;
 }
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tsl.setGain(TSL2561_GAIN_16X);     /* 16x gain ... use in low light to boost sen
 tsl.enableAutoGain(true);          /* Auto-gain ... switches automatically between 1x and 16x */
 ```
 
-The driver also supports as automatic clipping detection, and will return '0' lux when the sensor is saturated and data is unreliable.
+The driver also supports as automatic clipping detection, and will return '65536' lux when the sensor is saturated and data is unreliable. tsl.getEvent will return false in case of saturation and true in case of valid light data.
 
 ## About the TSL2561 ##
 


### PR DESCRIPTION
Current version of the library returns 0 in event.light in case of saturation. As a value of 0 could be a valid value in absolute darkness (tested by me) it is better to return a value > 65535 to report saturation and return false from getEvent in that case!

This change request returns 65536 (1 more than max possible value) and false from getEvent in case of saturation.

Successfully tested in my own application and backward compatible. 

- As event.light is declared as a float in Adafruit_Sensor_ESP.h a value of 65536 is a valid value and should not crash existing applications of the library.
- As getEvent was returning always true the change should not crash existing applications of the library.