### PR TITLE
Added support for esp8266

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -22,6 +22,8 @@
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
 #include <util/delay.h>
+#elif defined(ESP8266)
+#include <pgmspace.h>
 #else
 #include "pgmspace.h"
 #endif


### PR DESCRIPTION
Fixes: Adafruit_TSL2561/pgmspace.h:60:32: error: expected unqualified-id before 'const'
       #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
