### PR TITLE
Added support for Teensy 3.x and made Wire port selectable in setup

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -22,7 +22,7 @@
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
 #include <util/delay.h>
-#else
+#elif !defined(TEENSYDUINO)
 #include "pgmspace.h"
 #endif
 #include <stdlib.h>
@@ -44,15 +44,15 @@
 /**************************************************************************/
 void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 {
-  Wire.beginTransmission(_addr);
+  wire -> beginTransmission(_addr);
   #if ARDUINO >= 100
-  Wire.write(reg);
-  Wire.write(value & 0xFF);
+  wire -> write(reg);
+  wire -> write(value & 0xFF);
   #else
-  Wire.send(reg);
-  Wire.send(value & 0xFF);
+  wire -> send(reg);
+  wire -> send(value & 0xFF);
   #endif
-  Wire.endTransmission();
+  wire -> endTransmission();
 }
 
 /**************************************************************************/
@@ -62,19 +62,19 @@ void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 /**************************************************************************/
 uint8_t Adafruit_TSL2561_Unified::read8(uint8_t reg)
 {
-  Wire.beginTransmission(_addr);
+  wire -> beginTransmission(_addr);
   #if ARDUINO >= 100
-  Wire.write(reg);
+  wire -> write(reg);
   #else
-  Wire.send(reg);
+  wire -> send(reg);
   #endif
-  Wire.endTransmission();
+  wire -> endTransmission();
 
-  Wire.requestFrom(_addr, 1);
+  wire -> requestFrom(_addr, 1);
   #if ARDUINO >= 100
-  return Wire.read();
+  return wire -> read();
   #else
-  return Wire.receive();
+  return wire -> receive();
   #endif
 }
 
@@ -87,21 +87,21 @@ uint16_t Adafruit_TSL2561_Unified::read16(uint8_t reg)
 {
   uint16_t x; uint16_t t;
 
-  Wire.beginTransmission(_addr);
+  wire -> beginTransmission(_addr);
   #if ARDUINO >= 100
-  Wire.write(reg);
+  wire -> write(reg);
   #else
-  Wire.send(reg);
+  wire -> send(reg);
   #endif
-  Wire.endTransmission();
+  wire -> endTransmission();
 
-  Wire.requestFrom(_addr, 2);
+  wire -> requestFrom(_addr, 2);
   #if ARDUINO >= 100
-  t = Wire.read();
-  x = Wire.read();
+  t = wire -> read();
+  x = wire -> read();
   #else
-  t = Wire.receive();
-  x = Wire.receive();
+  t = wire -> receive();
+  x = wire -> receive();
   #endif
   x <<= 8;
   x |= t;
@@ -193,10 +193,22 @@ Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorI
     doing anything else)
 */
 /**************************************************************************/
-boolean Adafruit_TSL2561_Unified::begin(void) 
+boolean Adafruit_TSL2561_Unified::begin() 
 {
-  Wire.begin();
+  wire = &Wire;
+  wire -> begin();
+  return init();
+}
 
+boolean Adafruit_TSL2561_Unified::begin(TwoWire *theWire) 
+{
+  wire = theWire;
+  wire -> begin();
+  return init();
+}
+
+boolean Adafruit_TSL2561_Unified::init()
+{
   /* Make sure we're actually connected */
   uint8_t x = read8(TSL2561_REGISTER_ID);
   if (!(x & 0x0A))

--- a/Adafruit_TSL2561_U.h
+++ b/Adafruit_TSL2561_U.h
@@ -42,6 +42,7 @@
  #include <WProgram.h>
 #endif
 #include <Adafruit_Sensor.h>
+#include "HardwareSerial.h"
 
 #ifdef __AVR_ATtiny85__
   #include "TinyWireM.h"
@@ -179,6 +180,8 @@ class Adafruit_TSL2561_Unified : public Adafruit_Sensor {
  public:
   Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID = -1);
   boolean begin(void);
+  boolean begin(TwoWire *theWire);
+  boolean init();
   
   /* TSL2561 Functions */
   void enableAutoRange(bool enable);
@@ -192,6 +195,8 @@ class Adafruit_TSL2561_Unified : public Adafruit_Sensor {
   void getSensor(sensor_t*);
 
  private:
+  TwoWire *wire;
+ 
   int8_t _addr;
   boolean _tsl2561Initialised;
   boolean _tsl2561AutoGain;

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -94,7 +94,9 @@ void setup(void)
   Serial.println("Light Sensor Test"); Serial.println("");
   
   /* Initialise the sensor */
-  if(!tsl.begin(&Wire2))  //use tsl.begin() to default to Wire, &Wire2 directs api to use Wire2, etc.
+  //use tsl.begin() to default to Wire, 
+  //tsl.begin(&Wire2) directs api to use Wire2, etc.
+  if(!tsl.begin())
   {
     /* There was a problem detecting the TSL2561 ... check your connections */
     Serial.print("Ooops, no TSL2561 detected ... Check your wiring or I2C ADDR!");

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -94,7 +94,7 @@ void setup(void)
   Serial.println("Light Sensor Test"); Serial.println("");
   
   /* Initialise the sensor */
-  if(!tsl.begin())
+  if(!tsl.begin(&Wire2))  //use tsl.begin() to default to Wire, &Wire2 directs api to use Wire2, etc.
   {
     /* There was a problem detecting the TSL2561 ... check your connections */
     Serial.print("Ooops, no TSL2561 detected ... Check your wiring or I2C ADDR!");


### PR DESCRIPTION
-  Scope of Change:
Added support for Teensy 3.x series of microcontrollers - excluded pgmspace.h if TEENSYDUINO is used.  Additionally, added the compatibility to select which Wire port you would like to use with the sensor.  For instance:
1.  if you use tsl.begin() in the example it will default to Wire or you can also use tsl.begin(&Wire) but not necessary,
2.  If you want to use Wire2 (Teensy 3.5/3.6 have Wire, Wire1, Wire2 that you can use.

- Limitation:
The only limitation is that there is no default test if you select a Wire port that is not available.

- Test:
Ran a test on the Teensy 3.5 with the sensor on Wire2 and worked fine.

Thanks for considering this change
Mike