### PR TITLE
Add support for TSL2561 level interrupts

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -45,7 +45,6 @@
 /**************************************************************************/
 void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 {
-  DEBUGOUT.print(" *** TSL2561: write8, register = 0x"); DEBUGOUT.print(reg, HEX); DEBUGOUT.print(" / data: 0x"); DEBUGOUT.println(value, HEX);
   wire -> beginTransmission(_addr);
   #if ARDUINO >= 100
   wire -> write(reg);
@@ -64,7 +63,6 @@ void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 /**************************************************************************/
 void Adafruit_TSL2561_Unified::writereg8 (uint8_t reg)
 {
-  DEBUGOUT.print(" *** TSL2561: writereg8, register = 0x"); DEBUGOUT.println(reg, HEX);
   wire -> beginTransmission(_addr);
   #if ARDUINO >= 100
   wire -> write(reg);
@@ -192,9 +190,6 @@ void Adafruit_TSL2561_Unified::getData (uint16_t *broadband, uint16_t *ir)
 
   /* Reads a two byte value from channel 1 (infrared) */
   *ir = read16(TSL2561_COMMAND_BIT | TSL2561_WORD_BIT | TSL2561_REGISTER_CHAN1_LOW);
-
-  // OUTPUT RAW MEASURED VALUES
-  DEBUGOUT.print(" *** TSL: Raw measurement data: chan0 = 0x"); DEBUGOUT.print(*broadband,HEX); DEBUGOUT.print(" / chan1 = 0x"); DEBUGOUT.println(*ir, HEX);
 
   /* Turn the device off to save power */
   if(_allowSleep) disable();
@@ -528,6 +523,172 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
 
 /**************************************************************************/
 /*!
+    Converts a standard SI lux value to a raw sensor value (for channel 0),
+    taking into account the configured gain for the sensor. Required for
+    SI lux consistency, and needed for interrupt threshold configuration.
+
+    Important:
+     * first configure the integration time and gain.
+     * in case of autogain, the gain factor can be adjusted depending on the
+       measurement; you might want to perform a measurement first to autoconfigure
+       it, or avoid autogain alltogether with interrupts.
+     * changing the integration value requires changing the interrupt thresholds!
+
+    -----------------------------------------------------------------------
+
+    TIJA: So, funny story: the raw values (ch0/ch1) to lux conversion takes
+    both values into account. For interrupts, we can only configure a
+    threshold for channel 0. So the problem is: given a lux value, can
+    we make an educated guess for what the channel 0 value would be, leaving
+    channel 1 as an undetermined parameter?
+
+    If you look at the datasheet p23, you'll see the ratio of both is
+    determining what formula to use.
+    (https://cdn-shop.adafruit.com/datasheets/TSL2561.pdf)
+
+    Here, we take the naieve assumption that the expected ratio is that as
+    covered by the sensitivity curves of Figure 4, p8. The ratio of the
+    area under both curves is roughly:
+      * area under curve channel0: 24 squares
+      * area under curve channel1: 7.5 squares
+      * ratio of areas under curve: 7.5 / 24 = 0.3125
+
+    So the most unbiased estimation for the ration is somewhere around 0.31 - 0.32.
+    For conditions under sunlight, this was experimentally verified and more or
+    less holds. Under artificial light (e.g. LED light), the IR component is
+    (not very surprisingly) much smaller and leans more towards ratio 0.11 !!!
+    Very roughly speaking the (black body) light spectrum of the sun is, again
+    very roughly speaking, ""uniform"" (*cough* cutting corners *cough*) across
+    the sensitivity range of the sensor (300-1100nm wavelength).
+
+    It is possible to supply different estimations for the ratio, depending
+    on your specific lighting conditions where you need thresholds (because that
+    would be the only situation where I would recommend using this function).
+
+      TSL2561_APPROXCHRATIO_SUN = 0.325
+      TSL2561_APPROXCHRATIO_LED = 0.100
+
+    The formula's, I refer to p23 of the datasheet to see where they come from
+    (which seems to be an empiric formula from TAOS).
+
+    Note: below is a mixture of fixed point & floating point math; sorry, did
+    not have the time to rewrite everything in fixed point math.
+
+*/
+/**************************************************************************/
+uint32_t Adafruit_TSL2561_Unified::calculateRawCH0(uint16_t lux, float approxChRatio)
+{
+  unsigned long luxScale;
+  unsigned long ch0Scale = 0;
+  unsigned long chScale;
+
+  /* First, go to fixed point math scale -- reference scale is 2^TSL2561_LUX_CHSCALE = 2^10 */
+  luxScale = (lux << TSL2561_LUX_CHSCALE);
+
+  /* Next, calculate from lux to (scaled) channel0 values */
+#ifdef TSL2561_PACKAGE_CS
+  // CS Package
+  // ----------------------
+  // For calculating CH1/CH0 to Lux (p23 datasheet):
+  //    For 0 < CH1/CH0 < 0.52      Lux = 0.0315 * CH0 - 0.0593 * CH0 * ((CH1/CH0)^1.4)
+  //    For 0.52 < CH1/CH0 < 0.65   Lux = 0.0229 * CH0 - 0.0291 * CH1
+  //    For 0.65 < CH1/CH0 < 0.80   Lux = 0.0157 * CH0 - 0.0180 * CH1
+  //    For 0.80 < CH1/CH0 < 1.30   Lux = 0.00338 * CH0 - 0.00260 * CH1
+  //    For CH1/CH0 > 1.30          Lux = 0
+  //
+  // Replacing CH1 = (CH1/CH0) * CH0 = approxChRatio * CH0, we can solve all
+  // of these for CH0:
+  //
+  //    For 0 < CH1/CH0 < 0.52      Lux = (0.0315 - 0.0593 * ((approxChRatio)^1.4) )* CH0
+  //    For 0.52 < CH1/CH0 < 0.65   Lux = (0.0229 - 0.0291 * approxChRatio) * CH0
+  //    For 0.65 < CH1/CH0 < 0.80   Lux = (0.0157 - 0.0180 * approxChRatio) * CH0
+  //    For 0.80 < CH1/CH0 < 1.30   Lux = (0.00338 - 0.00260 * approxChRatio) * CH0
+  //    For CH1/CH0 > 1.30          Lux = 0
+  //
+
+  float divisor = 1;
+  if(approxChRatio > 1.30) {
+    return 0xFFFF;
+  } else if(approxChRatio > 0.80) {
+    divisor = (0.00338 - 0.00260 * approxChRatio);
+  } else if(approxChRatio > 0.65) {
+    divisor = (0.0157 - 0.0180 * approxChRatio);
+  } else if(approxChRatio > 0.52) {
+    divisor = (0.0229 - 0.0291 * approxChRatio);
+  } else {
+    // 0 < chRatio < 0.50
+    divisor = (0.0315 - 0.0593 * pow(approxChRatio, 1.4));
+  }
+#else
+  // T, FN, and CL Package
+  // ----------------------
+  // For calculating CH1/CH0 to Lux (p23 datasheet):
+  //    For 0 < CH1/CH0 < 0.50     Lux = 0.0304 * CH0 - 0.062 * CH0 * ((CH1/CH0)^1.4)
+  //    For 0.50 < CH1/CH0 < 0.61  Lux = 0.0224 * CH0 - 0.031 * CH1
+  //    For 0.61 < CH1/CH0 < 0.80  Lux = 0.0128  * CH0 - 0.0153 * CH1
+  //    For 0.80 < CH1/CH0 < 1.30  Lux = 0.00146 * CH0 - 0.00112 * CH1
+  //    For CH1/CH0 > 1.30         Lux = 0
+  //
+  // Replacing CH1 = (CH1/CH0) * CH0 = approxChRatio * CH0, we can solve all
+  // of these for CH0:
+  //
+  //    For 0 < CH1/CH0 < 0.50     Lux = ( 0.0304 - 0.062 * ((approxChRatio)^1.4)) * CH0
+  //    For 0.50 < CH1/CH0 < 0.61  Lux = (0.0224 - 0.031 * approxChRatio) * CH0
+  //    For 0.61 < CH1/CH0 < 0.80  Lux = (0.0128 - 0.0153 * approxChRatio) * CH0
+  //    For 0.80 < CH1/CH0 < 1.30  Lux = (0.00146 - 0.00112 * approxChRatio) * CH0
+  //    For CH1/CH0 > 1.30         Lux = 0 --> we return the highest possible value 0xFFFF
+  //
+
+  float divisor = 1;
+  if(approxChRatio > 1.30) {
+    // Easy one :)
+    return 0xFFFF;
+  } else if(approxChRatio > 0.80) {
+    divisor = (0.00146 - 0.00112 * approxChRatio);
+  } else if(approxChRatio > 0.61) {
+    divisor = (0.0128 - 0.0153 * approxChRatio);
+  } else if(approxChRatio > 0.50) {
+    divisor = (0.0224 - 0.031 * approxChRatio);
+  } else {
+    // 0 < chRatio < 0.50
+    divisor = (0.0304 - 0.062 * pow(approxChRatio, 1.4));
+  }
+
+  // Calculate CH0 value (fixed point scaled)
+  if (divisor > 0) {
+    ch0Scale = (unsigned long)(luxScale / divisor);
+  } else {
+    return 0xFFFF;
+  }
+#endif
+
+  /* Now, we need to scale back down... the correct scale depends on the
+     integration time and the gain */
+
+  switch (_tsl2561IntegrationTime)
+  {
+    case TSL2561_INTEGRATIONTIME_13MS:
+      chScale = TSL2561_LUX_CHSCALE_TINT0;
+      break;
+    case TSL2561_INTEGRATIONTIME_101MS:
+      chScale = TSL2561_LUX_CHSCALE_TINT1;
+      break;
+    default: /* No scaling ... integration time = 402ms */
+      chScale = (1 << TSL2561_LUX_CHSCALE);
+      break;
+  }
+
+  /* Scale for gain (1x or 16x) */
+  if (!_tsl2561Gain) {
+    chScale = chScale << 4;
+  }
+
+  /* Scale the channel value back */
+  return (ch0Scale / chScale);
+}
+
+/**************************************************************************/
+/*!
     @brief  Gets the most recent sensor event
     returns true if sensor reading is between 0 and 65535 lux
     returns false if sensor is saturated
@@ -612,8 +773,6 @@ void Adafruit_TSL2561_Unified::setInterruptControl(tsl2561InterruptControl_t int
   uint8_t cmd = TSL2561_COMMAND_BIT | TSL2561_REGISTER_INTERRUPT;
   uint8_t data = ((intcontrol & 0B00000011) << 4) | (intpersist & 0B00001111);
 
-  DEBUGOUT.print(" *** TSL2561: setInterruptControl, register = 0x"); DEBUGOUT.print(cmd, HEX); DEBUGOUT.print(" / data: 0x"); DEBUGOUT.println(data, HEX);
-
   /* Update the interrupt control register */
   write8(cmd, data);
 
@@ -622,19 +781,15 @@ void Adafruit_TSL2561_Unified::setInterruptControl(tsl2561InterruptControl_t int
   if(_allowSleep) disable();
 }
 
-
-
-
-
-//
-// low, high: 16-bit threshold values
-// Returns true (1) if successful, false (0) if there was an I2C error
-// (Also see getError() below)
-
 /**************************************************************************/
 /*!
     @brief  Set interrupt thresholds (TSL2561 supports only interrupts
-    generated by thresholds on channel 0)
+    generated by thresholds on channel 0).
+
+    Important: values supplied as thresholds are raw sensor values, and
+    NOT values in the SI lux unit. In order to get an estimation of the
+    raw value to pass here when you want a lux value as a threshold, use
+    the calculateRawCH0() function with the right approximation parameter.
 */
 /**************************************************************************/
 

--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************/
 /*!
     @file     Adafruit_TSL2561.cpp
-    @author   K.Townsend (Adafruit Industries)
+    @author   K.Townsend (Adafruit Industries), T.Jacobs (CegekaLabs)
     @license  BSD (see license.txt)
 
     Driver for the TSL2561 digital luminosity (light) sensors.
@@ -14,6 +14,7 @@
 
     @section  HISTORY
 
+    v3.0 - Added interrupt support
     v2.0 - Rewrote driver for Adafruit_Sensor and Auto-Gain support, and
            added lux clipping check (returns 0 lux on sensor saturation)
     v1.0 - First release (previously TSL2561)
@@ -44,6 +45,7 @@
 /**************************************************************************/
 void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 {
+  DEBUGOUT.print(" *** TSL2561: write8, register = 0x"); DEBUGOUT.print(reg, HEX); DEBUGOUT.print(" / data: 0x"); DEBUGOUT.println(value, HEX);
   wire -> beginTransmission(_addr);
   #if ARDUINO >= 100
   wire -> write(reg);
@@ -53,6 +55,37 @@ void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
   wire -> send(value & 0xFF);
   #endif
   wire -> endTransmission();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Writes a register over I2C
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::writereg8 (uint8_t reg)
+{
+  DEBUGOUT.print(" *** TSL2561: writereg8, register = 0x"); DEBUGOUT.println(reg, HEX);
+  wire -> beginTransmission(_addr);
+  #if ARDUINO >= 100
+  wire -> write(reg);
+  #else
+  wire -> send(reg);
+  #endif
+  wire -> endTransmission();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Writes a register and an 16 bit value over I2C
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::write16 (uint8_t reg, uint32_t value)
+{
+  // Only accept at highest TSL2561_REGISTER_CHAN1_LOW = 0x0E as input
+  if((reg & 0x0F) < 0x0F) {
+    write8(reg, lowByte(value));
+    write8(reg+1, highByte(value));
+  }
 }
 
 /**************************************************************************/
@@ -160,8 +193,11 @@ void Adafruit_TSL2561_Unified::getData (uint16_t *broadband, uint16_t *ir)
   /* Reads a two byte value from channel 1 (infrared) */
   *ir = read16(TSL2561_COMMAND_BIT | TSL2561_WORD_BIT | TSL2561_REGISTER_CHAN1_LOW);
 
+  // OUTPUT RAW MEASURED VALUES
+  DEBUGOUT.print(" *** TSL: Raw measurement data: chan0 = 0x"); DEBUGOUT.print(*broadband,HEX); DEBUGOUT.print(" / chan1 = 0x"); DEBUGOUT.println(*ir, HEX);
+
   /* Turn the device off to save power */
-  disable();
+  if(_allowSleep) disable();
 }
 
 /*========================================================================*/
@@ -171,9 +207,13 @@ void Adafruit_TSL2561_Unified::getData (uint16_t *broadband, uint16_t *ir)
 /**************************************************************************/
 /*!
     Constructor
+
+    allowSleep      When true, puts the device to sleep after every operation,
+                    to conserve power. Do not put the device to sleep if
+                    you are using interrupts, i.e. supply false here.
 */
 /**************************************************************************/
-Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID) 
+Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID, bool allowSleep)
 {
   _addr = addr;
   _tsl2561Initialised = false;
@@ -181,6 +221,7 @@ Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorI
   _tsl2561IntegrationTime = TSL2561_INTEGRATIONTIME_13MS;
   _tsl2561Gain = TSL2561_GAIN_1X;
   _tsl2561SensorID = sensorID;
+  _allowSleep = allowSleep;
 }
 
 /*========================================================================*/
@@ -193,14 +234,14 @@ Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorI
     doing anything else)
 */
 /**************************************************************************/
-boolean Adafruit_TSL2561_Unified::begin() 
+boolean Adafruit_TSL2561_Unified::begin()
 {
   wire = &Wire;
   wire -> begin();
   return init();
 }
 
-boolean Adafruit_TSL2561_Unified::begin(TwoWire *theWire) 
+boolean Adafruit_TSL2561_Unified::begin(TwoWire *theWire)
 {
   wire = theWire;
   wire -> begin();
@@ -222,11 +263,11 @@ boolean Adafruit_TSL2561_Unified::init()
   setGain(_tsl2561Gain);
 
   /* Note: by default, the device is in power down mode on bootup */
-  disable();
+  if(_allowSleep) disable();
 
   return true;
 }
-  
+
 /**************************************************************************/
 /*!
     @brief  Enables or disables the auto-gain settings when reading
@@ -257,7 +298,7 @@ void Adafruit_TSL2561_Unified::setIntegrationTime(tsl2561IntegrationTime_t time)
   _tsl2561IntegrationTime = time;
 
   /* Turn the device off to save power */
-  disable();
+  if(_allowSleep) disable();
 }
 
 /**************************************************************************/
@@ -279,7 +320,7 @@ void Adafruit_TSL2561_Unified::setGain(tsl2561Gain_t gain)
   _tsl2561Gain = gain;
 
   /* Turn the device off to save power */
-  disable();
+  if(_allowSleep) disable();
 }
 
 /**************************************************************************/
@@ -380,8 +421,8 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
 {
   unsigned long chScale;
   unsigned long channel1;
-  unsigned long channel0;  
-  
+  unsigned long channel0;
+
   /* Make sure the sensor isn't saturated! */
   uint16_t clipThreshold;
   switch (_tsl2561IntegrationTime)
@@ -495,10 +536,10 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
 bool Adafruit_TSL2561_Unified::getEvent(sensors_event_t *event)
 {
   uint16_t broadband, ir;
-  
+
   /* Clear the event */
   memset(event, 0, sizeof(sensors_event_t));
-  
+
   event->version   = sizeof(sensors_event_t);
   event->sensor_id = _tsl2561SensorID;
   event->type      = SENSOR_TYPE_LIGHT;
@@ -507,9 +548,9 @@ bool Adafruit_TSL2561_Unified::getEvent(sensors_event_t *event)
   /* Calculate the actual lux value */
   getLuminosity(&broadband, &ir);
   event->light = calculateLux(broadband, ir);
-  
+
   if (event->light == 65536) {
-    return false;	
+    return false;
   }
   return true;
 }
@@ -534,4 +575,82 @@ void Adafruit_TSL2561_Unified::getSensor(sensor_t *sensor)
   sensor->max_value   = 17000.0;  /* Based on trial and error ... confirm! */
   sensor->min_value   = 0.0;
   sensor->resolution  = 1.0;
+}
+
+
+/**************************************************************************/
+/*!
+    @brief  Sets up interrupt control on the TSL2561
+
+    Values for control & persist:
+      TSL2561_INTERRUPTCTL_DISABLE: interrupt output disabled
+      TSL2561_INTERRUPTCTL_LEVEL: use level interrupt, see setInterruptThreshold(),
+          datasheet calls this "traditional interrupt".
+      TSL2561_INTERRUPTCTL_SMBALERT: if you need this, you'll know what this means :).
+      TSL2561_INTERRUPTCTL_TEST: Sets interrupt and functions like SMBALERT mode.
+
+      intpersist = 0, every integration cycle generates an interrupt
+      intpersist = 1, any value outside of threshold generates an interrupt
+      intpersist = 2 to 15, value must be outside of threshold for 2 to 15 integration cycles
+
+      Note: A persist value of 0 causes an interrupt to occur after every integration cycle regardless
+      of the threshold settings. A value of 1 results in an interrupt after one integration
+      time period outside the threshold window. A value of N (where N is 2 through 15) results
+      in an interrupt only if the value remains outside the threshold window for N consecutive
+      integration cycles. For example, if N is equal to 10 and the integration time is 402 ms,
+      then the total time is approximately 4 seconds.
+
+*/
+/**************************************************************************/
+
+void Adafruit_TSL2561_Unified::setInterruptControl(tsl2561InterruptControl_t intcontrol, uint8_t intpersist) {
+  // Are we initialized?
+  if (!_tsl2561Initialised) begin();
+  /* Enable the device by setting the control bit to 0x03 */
+  enable();
+
+  uint8_t cmd = TSL2561_COMMAND_BIT | TSL2561_REGISTER_INTERRUPT;
+  uint8_t data = ((intcontrol & 0B00000011) << 4) | (intpersist & 0B00001111);
+
+  DEBUGOUT.print(" *** TSL2561: setInterruptControl, register = 0x"); DEBUGOUT.print(cmd, HEX); DEBUGOUT.print(" / data: 0x"); DEBUGOUT.println(data, HEX);
+
+  /* Update the interrupt control register */
+  write8(cmd, data);
+
+  /* Turn the device off to save power */
+  // NOTE: This disables interrupts so no good idea if you need them :)
+  if(_allowSleep) disable();
+}
+
+
+
+
+
+//
+// low, high: 16-bit threshold values
+// Returns true (1) if successful, false (0) if there was an I2C error
+// (Also see getError() below)
+
+/**************************************************************************/
+/*!
+    @brief  Set interrupt thresholds (TSL2561 supports only interrupts
+    generated by thresholds on channel 0)
+*/
+/**************************************************************************/
+
+void Adafruit_TSL2561_Unified::setInterruptThreshold(uint16_t lowThreshold, uint16_t highThreshold) {
+	// Write low and high threshold values
+	write16(TSL2561_COMMAND_BIT | TSL2561_REGISTER_THRESHHOLDL_LOW , lowThreshold);
+  write16(TSL2561_COMMAND_BIT | TSL2561_REGISTER_THRESHHOLDH_LOW , highThreshold);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Clears an active interrupt
+*/
+/**************************************************************************/
+
+void Adafruit_TSL2561_Unified::clearLevelInterrupt(void) {
+	// Send command byte for interrupt clear
+  writereg8(TSL2561_COMMAND_BIT | TSL2561_CLEAR_BIT);
 }

--- a/Adafruit_TSL2561_U.h
+++ b/Adafruit_TSL2561_U.h
@@ -150,6 +150,11 @@
 #define TSL2561_CLIPPING_101MS    (37000)
 #define TSL2561_CLIPPING_402MS    (65000)
 
+// Approximations for Channel 1 to Channel 0 ratio for specific light conditions
+// -> See discussion near calculateRawCH0() function for details
+#define TSL2561_APPROXCHRATIO_SUN 0.325
+#define TSL2561_APPROXCHRATIO_LED 0.100
+
 enum
 {
   TSL2561_REGISTER_CONTROL          = 0x00,
@@ -205,6 +210,7 @@ class Adafruit_TSL2561_Unified : public Adafruit_Sensor {
   void setGain(tsl2561Gain_t gain);
   void getLuminosity (uint16_t *broadband, uint16_t *ir);
   uint32_t calculateLux(uint16_t broadband, uint16_t ir);
+  uint32_t calculateRawCH0(uint16_t lux, float approxChRatio = TSL2561_APPROXCHRATIO_SUN);
 
   /* Unified Sensor API Functions */
   bool getEvent(sensors_event_t*);

--- a/Adafruit_TSL2561_U.h
+++ b/Adafruit_TSL2561_U.h
@@ -1,7 +1,7 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     Adafruit_TSL2561.h
-    @author   K. Townsend (Adafruit Industries)
+    @author   K. Townsend (Adafruit Industries), T.Jacobs (CegekaLabs)
 
     @section LICENSE
 
@@ -31,6 +31,12 @@
     ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/*
+    Interrupt Control additions performed by Tim Jacobs in 2017
+
+    Inspired by code available here:
+    https://github.com/sparkfun/TSL2561_Luminosity_Sensor_BOB
 */
 /**************************************************************************/
 #ifndef _TSL2561_H_
@@ -176,39 +182,59 @@ typedef enum
 }
 tsl2561Gain_t;
 
+typedef enum
+{
+  TSL2561_INTERRUPTCTL_DISABLE         = 0x00,    // 0B00
+  TSL2561_INTERRUPTCTL_LEVEL           = 0x01,    // 0B01
+  TSL2561_INTERRUPTCTL_SMBALERT        = 0x02,    // 0B10
+  TSL2561_INTERRUPTCTL_TEST            = 0x03     // 0B11
+}
+tsl2561InterruptControl_t;
+
+
 class Adafruit_TSL2561_Unified : public Adafruit_Sensor {
  public:
-  Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID = -1);
+  Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID = -1, bool allowSleep = true);
   boolean begin(void);
   boolean begin(TwoWire *theWire);
   boolean init();
-  
+
   /* TSL2561 Functions */
   void enableAutoRange(bool enable);
   void setIntegrationTime(tsl2561IntegrationTime_t time);
   void setGain(tsl2561Gain_t gain);
   void getLuminosity (uint16_t *broadband, uint16_t *ir);
   uint32_t calculateLux(uint16_t broadband, uint16_t ir);
-  
-  /* Unified Sensor API Functions */  
+
+  /* Unified Sensor API Functions */
   bool getEvent(sensors_event_t*);
   void getSensor(sensor_t*);
 
+  // Interrupt functions
+  void setInterruptControl(tsl2561InterruptControl_t intcontrol, uint8_t intpersist);
+  void setInterruptThreshold(uint16_t lowThreshold, uint16_t highThreshold);
+  void clearLevelInterrupt(void);
+
  private:
   TwoWire *wire;
- 
+
   int8_t _addr;
   boolean _tsl2561Initialised;
   boolean _tsl2561AutoGain;
   tsl2561IntegrationTime_t _tsl2561IntegrationTime;
   tsl2561Gain_t _tsl2561Gain;
   int32_t _tsl2561SensorID;
-  
+  boolean _allowSleep;
+
   void     enable (void);
   void     disable (void);
   void     write8 (uint8_t reg, uint32_t value);
+  void     writereg8 (uint8_t reg);
+  void    write16 (uint8_t reg, uint32_t value);
   uint8_t  read8 (uint8_t reg);
   uint16_t read16 (uint8_t reg);
   void     getData (uint16_t *broadband, uint16_t *ir);
+
+
 };
 #endif

--- a/examples/interrupts/interrupts.ino
+++ b/examples/interrupts/interrupts.ino
@@ -1,0 +1,169 @@
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include <Adafruit_TSL2561_U.h>
+
+/* This driver uses the Adafruit unified sensor library (Adafruit_Sensor),
+   which provides a common 'type' for sensor data and some helper functions.
+
+   To use this driver you will also need to download the Adafruit_Sensor
+   library and include it in your libraries folder.
+
+   You should also assign a unique ID to this sensor for use with
+   the Adafruit Sensor API so that you can identify this particular
+   sensor in any data logs, etc.  To assign a unique ID, simply
+   provide an appropriate value in the constructor below (12345
+   is used by default in this example).
+
+   Connections
+   ===========
+   Connect SCL to analog 5
+   Connect SDA to analog 4
+   Connect VDD to 3.3V DC
+   Connect GROUND to common ground
+
+   I2C Address
+   ===========
+   The address will be different depending on whether you leave
+   the ADDR pin floating (addr 0x39), or tie it to ground or vcc.
+   The default addess is 0x39, which assumes the ADDR pin is floating
+   (not connected to anything).  If you set the ADDR pin high
+   or low, use TSL2561_ADDR_HIGH (0x49) or TSL2561_ADDR_LOW
+   (0x29) respectively.
+
+   History
+   =======
+   2013/JAN/31  - First version (KTOWN)
+*/
+
+Adafruit_TSL2561_Unified tsl = Adafruit_TSL2561_Unified(TSL2561_ADDR_FLOAT, 12345);
+
+// We assume the Adafruit TSL2561's "int" pin is attached to this digital pin
+#define INTERRUPT_PIN 0
+
+/**************************************************************************/
+/*
+    Displays some basic information on this sensor from the unified
+    sensor API sensor_t type (see Adafruit_Sensor for more information)
+*/
+/**************************************************************************/
+void displaySensorDetails(void)
+{
+  sensor_t sensor;
+  tsl.getSensor(&sensor);
+  Serial.println("------------------------------------");
+  Serial.print  ("Sensor:       "); Serial.println(sensor.name);
+  Serial.print  ("Driver Ver:   "); Serial.println(sensor.version);
+  Serial.print  ("Unique ID:    "); Serial.println(sensor.sensor_id);
+  Serial.print  ("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" lux");
+  Serial.print  ("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" lux");
+  Serial.print  ("Resolution:   "); Serial.print(sensor.resolution); Serial.println(" lux");
+  Serial.println("------------------------------------");
+  Serial.println("");
+  delay(500);
+}
+
+/**************************************************************************/
+/*
+    Configures the gain and integration time for the TSL2561
+*/
+/**************************************************************************/
+void configureSensor(void)
+{
+  /* You can also manually set the gain or enable auto-gain support */
+  // tsl.setGain(TSL2561_GAIN_1X);      /* No gain ... use in bright light to avoid sensor saturation */
+  // tsl.setGain(TSL2561_GAIN_16X);     /* 16x gain ... use in low light to boost sensitivity */
+  tsl.enableAutoRange(true);            /* Auto-gain ... switches automatically between 1x and 16x */
+
+  /* Changing the integration time gives you better sensor resolution (402ms = 16-bit data) */
+  tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_13MS);      /* fast but low resolution */
+  // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_101MS);  /* medium resolution and speed   */
+  // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_402MS);  /* 16-bit data but slowest conversions */
+
+  /* Configure interrupt thresholds
+     Note: value in raw sensor units, BEFORE being calculated to lux...
+     Calculating a given lux value to a sensor threshold value is left
+     as an exercise for the reader :) */
+  tsl.setInterruptThreshold(0,3000);
+  /* Enable level interrupt, trigger interrupt after 5 integration times
+     -> Because integration time is 13ms by default, this means the threshold
+        needs to be exceeded for more than 65ms before the interrupt is triggered.
+        Maximum value is 15; put to 1 for immediate triggering; put to 0 to have
+        the interrupt triggered after every integration time (regardless of whether
+        the thresholds were exceeded or not)
+  */
+  tsl.setInterruptControl(TSL2561_INTERRUPTCTL_LEVEL, 5);
+  tsl.clearLevelInterrupt();
+
+  /* Update these values depending on what you've set above! */
+  Serial.println("------------------------------------");
+  Serial.print  ("Gain:         "); Serial.println("Auto");
+  Serial.print  ("Timing:       "); Serial.println("13 ms");
+  Serial.println("------------------------------------");
+}
+
+/**************************************************************************/
+/*
+    Arduino setup function (automatically called at startup)
+*/
+/**************************************************************************/
+void setup(void)
+{
+  Serial.begin(9600);
+  Serial.println("Light Sensor Test"); Serial.println("");
+
+  /* Configure the interrupt pin as input pin */
+  pinMode(INTERRUPT_PIN, INPUT_PULLUP);
+
+  /* Initialise the sensor */
+  //use tsl.begin() to default to Wire,
+  //tsl.begin(&Wire2) directs api to use Wire2, etc.
+  if(!tsl.begin())
+  {
+    /* There was a problem detecting the TSL2561 ... check your connections */
+    Serial.print("Ooops, no TSL2561 detected ... Check your wiring or I2C ADDR!");
+    while(1);
+  }
+
+  /* Display some basic information on this sensor */
+  displaySensorDetails();
+
+  /* Setup the sensor gain and integration time */
+  configureSensor();
+
+  /* We're ready to go! */
+  Serial.println("");
+}
+
+/**************************************************************************/
+/*
+    Arduino loop function, called once 'setup' is complete (your own code
+    should go here)
+*/
+/**************************************************************************/
+void loop(void)
+{
+  /* Interrupt triggered? */
+  if(digitalRead(INTERRUPT_PIN) == LOW) {
+    // We have an interrupt!
+    Serial.println("TSL2561 reported interrupt thresholds exceeded!");
+    // Clear interrupt on sensor
+    tsl.clearLevelInterrupt();
+  }
+
+  /* Get a new sensor event */
+  sensors_event_t event;
+  tsl.getEvent(&event);
+
+  /* Display the results (light is measured in lux) */
+  if (event.light)
+  {
+    Serial.print(event.light); Serial.println(" lux");
+  }
+  else
+  {
+    /* If event.light = 0 lux the sensor is probably saturated
+       and no reliable data could be generated! */
+    Serial.println("Sensor overload");
+  }
+  delay(250);
+}

--- a/examples/interrupts/interrupts.ino
+++ b/examples/interrupts/interrupts.ino
@@ -79,11 +79,12 @@ void configureSensor(void)
   // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_101MS);  /* medium resolution and speed   */
   // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_402MS);  /* 16-bit data but slowest conversions */
 
-  /* Configure interrupt thresholds
-     Note: value in raw sensor units, BEFORE being calculated to lux...
-     Calculating a given lux value to a sensor threshold value is left
-     as an exercise for the reader :) */
-  tsl.setInterruptThreshold(0,3000);
+  /* Configure interrupt thresholds */
+  // First: convert lux value to raw sensor value, using "sunlight" approximation.
+  // Other approximations, see Adafruit_TSL2561_U.h
+  uint32_t threshold = tsl.calculateRawCH0(3000, TSL2561_APPROXCHRATIO_SUN);
+  tsl.setInterruptThreshold(0,threshold);
+
   /* Enable level interrupt, trigger interrupt after 5 integration times
      -> Because integration time is 13ms by default, this means the threshold
         needs to be exceeded for more than 65ms before the interrupt is triggered.


### PR DESCRIPTION
These changes add support for configuring level interrupts, supported by the TSL2561 luminosity sensor. Some important notes:

- Interrupts can be enabled using the `setInterruptThreshold` and `setInterruptControl` functions.
- Thresholds need to be configured in TSL2561 "native" units, and not in SI Lux units! I included a function called `calculateRawCH0` to estimate what "raw" or "native sensor" threshold value corresponds to what lux threshold value.
 - Example on using interrupts included

Improper clearing of interrupts leads to the TSL2561 to hang. Therefore, exercise caution when implementing interrupt code in your sketches.

Limitations:
- Only tested on SAMD21 platform (Arduino Zero/MKR1000/MKR1200/Feather M0/...)
- Example sketch not thoroughly tested ;).