### PR TITLE
Change ::init() to fix order of operations

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -107,7 +107,9 @@ boolean Adafruit_TSL2561_Unified::init()
 {
   /* Make sure we're actually connected */
   uint8_t x = read8(TSL2561_REGISTER_ID);
-  if ((x & 0xF0) != 0x0A) { // ID code for TSL2561
+  // Valid PartNumbers are 0x00, 0x02, 0x08, and 0x0A,
+  // if sensor is not connected x may return 0xFF
+  if (x & 0x05) {
     return false;
   }
   _tsl2561Initialised = true;

--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -107,7 +107,7 @@ boolean Adafruit_TSL2561_Unified::init()
 {
   /* Make sure we're actually connected */
   uint8_t x = read8(TSL2561_REGISTER_ID);
-  if (x & 0xF0 != 0x10) { // ID code for TSL2561
+  if ((x & 0xF0) != 0x0A) { // ID code for TSL2561
     return false;
   }
   _tsl2561Initialised = true;


### PR DESCRIPTION
**Scope of your change:**  Change init to better check for presence/un-presence of I2C device.

**Known limitations:** I'm not easily able to test on wide range of TSL2561 and it's possible the return value (0x0A) I'm seeing is returned only on some reversions.

**Test plan:**
 * Tested my TSL2561 (both with Arduino and Photon), I will ask some other use to also verify my change.
 * I don't like that `0x0A` is a magic constant. It doesn't seem to be the value (or little endian) that @ladyada [proposed ](https://github.com/adafruit/Adafruit_TSL2561/issues/11#issuecomment-359045180)in #13. It IS equal to TSL2561_REGISTER_ID which might be a red herring but concerns me. @beegee-tokyo Do you know where the value `0x0A` comes from?