### PR TITLE
Improved comments

### DIFF
--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -18,7 +18,7 @@
    ===========
    Connect SCL to I2C SCL Clock
    Connect SDA to I2C SDA Data
-   Connect VDD to 3.3V or 5V (whatever your logic level is)
+   Connect VCC to 3.3V or 5V (whatever your logic level is)
    Connect GROUND to common ground
 
    I2C Address

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -18,7 +18,7 @@
    ===========
    Connect SCL to I2C SCL Clock
    Connect SDA to I2C SDA Data
-   Connect VCC to 3.3V or 5V (whatever your logic level is)
+   Connect VCC to 3.3V or 5V (depending on sensor's logic level, check the datasheet)
    Connect GROUND to common ground
 
    I2C Address

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -18,7 +18,7 @@
    ===========
    Connect SCL to I2C SCL Clock
    Connect SDA to I2C SDA Data
-   Connect VCC to 3.3V or 5V (depending on sensor's logic level, check the datasheet)
+   Connect VCC/VDD to 3.3V or 5V (depends on sensor's logic level, check the datasheet)
    Connect GROUND to common ground
 
    I2C Address


### PR DESCRIPTION
**Changes:**

1. The first commit adds  "VCC" with "VDD" in the top section.
Because in many of the models of the sensor, the pin is marked as "VCC".
2. The second commit modifies a line and adds recommendation to check the datasheet to find out the appropriate logic level of the sensor.

As I was dealing with TSL2561, I found the previous line "whatever your logic level is" to be ambiguous. Because it doesn't tell whether its the microcontroller's logic level or the sensor's. So I modified the line so that it clarifies the confusion that may arise for beginners. Besides, its always a good idea to check the datasheet once again before making the connections. 