### PR TITLE
Fix for ESP32 with Compiler Warning:All

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -107,7 +107,7 @@ boolean Adafruit_TSL2561_Unified::init()
 {
   /* Make sure we're actually connected */
   uint8_t x = read8(TSL2561_REGISTER_ID);
-  if (x & 0xF0 != 0x10) { // ID code for TSL2561
+  if ((x & 0xF0) != 0x10) { // ID code for TSL2561
     return false;
   }
   _tsl2561Initialised = true;


### PR DESCRIPTION
I got this error with ESP32 with compiler warning:All
```
...\libraries\Adafruit_TSL2561\Adafruit_TSL2561_U.cpp:110:9: error: suggest parentheses around comparison in operand of '&' [-Werror=parentheses]

   if (x & 0xF0 != 0x10) { // ID code for TSL2561
```


I just added braces as suggested here : https://stackoverflow.com/questions/21919922/gcc-suggest-parentheses-around-comparison-parentheses-not-able-to-solve-myself