### PR TITLE
Add support for TSL2561 level interrupts

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file Adafruit_TSL2561_U.cpp
- *
+ * @author   K.Townsend (Adafruit Industries), T.Jacobs (CegekaLabs)
+ * @license  BSD (see license.txt)
  * @mainpage Adafruit TSL2561 Light/Lux sensor driver
  *
  * @section intro_sec Introduction
@@ -25,6 +26,7 @@
  * @section author Author
  *
  * Written by Kevin "KTOWN" Townsend for Adafruit Industries.
+ * Edited by Tim "CegekaLabs" Jacobs
  *
  * @section license License
  *
@@ -32,13 +34,184 @@
  *
  *   @section  HISTORY
  *
+ *   v3.0 - Added interrupt support
+ *
  *   v2.0 - Rewrote driver for Adafruit_Sensor and Auto-Gain support, and
  *          added lux clipping check (returns 0 lux on sensor saturation)
- *   v1.0 - First release (previously TSL2561)
-*/
+ *   v1.0 - First release (previously TSL2561)*/
 /**************************************************************************/
 
 #include "Adafruit_TSL2561_U.h"
+
+#define TSL2561_DELAY_INTTIME_13MS    (15)
+#define TSL2561_DELAY_INTTIME_101MS   (120)
+#define TSL2561_DELAY_INTTIME_402MS   (450)
+
+/*========================================================================*/
+/*                          PRIVATE FUNCTIONS                             */
+/*========================================================================*/
+
+/**************************************************************************/
+/*!
+    @brief  Writes a register and an 8 bit value over I2C
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
+{
+  DEBUGOUT.print(" *** TSL2561: write8, register = 0x"); DEBUGOUT.print(reg, HEX); DEBUGOUT.print(" / data: 0x"); DEBUGOUT.println(value, HEX);
+  wire -> beginTransmission(_addr);
+  #if ARDUINO >= 100
+  wire -> write(reg);
+  wire -> write(value & 0xFF);
+  #else
+  wire -> send(reg);
+  wire -> send(value & 0xFF);
+  #endif
+  wire -> endTransmission();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Writes a register over I2C
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::writereg8 (uint8_t reg)
+{
+  DEBUGOUT.print(" *** TSL2561: writereg8, register = 0x"); DEBUGOUT.println(reg, HEX);
+  wire -> beginTransmission(_addr);
+  #if ARDUINO >= 100
+  wire -> write(reg);
+  #else
+  wire -> send(reg);
+  #endif
+  wire -> endTransmission();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Writes a register and an 16 bit value over I2C
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::write16 (uint8_t reg, uint32_t value)
+{
+  // Only accept at highest TSL2561_REGISTER_CHAN1_LOW = 0x0E as input
+  if((reg & 0x0F) < 0x0F) {
+    write8(reg, lowByte(value));
+    write8(reg+1, highByte(value));
+  }
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reads an 8 bit value over I2C
+*/
+/**************************************************************************/
+uint8_t Adafruit_TSL2561_Unified::read8(uint8_t reg)
+{
+  wire -> beginTransmission(_addr);
+  #if ARDUINO >= 100
+  wire -> write(reg);
+  #else
+  wire -> send(reg);
+  #endif
+  wire -> endTransmission();
+
+  wire -> requestFrom(_addr, 1);
+  #if ARDUINO >= 100
+  return wire -> read();
+  #else
+  return wire -> receive();
+  #endif
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reads a 16 bit values over I2C
+*/
+/**************************************************************************/
+uint16_t Adafruit_TSL2561_Unified::read16(uint8_t reg)
+{
+  uint16_t x; uint16_t t;
+
+  wire -> beginTransmission(_addr);
+  #if ARDUINO >= 100
+  wire -> write(reg);
+  #else
+  wire -> send(reg);
+  #endif
+  wire -> endTransmission();
+
+  wire -> requestFrom(_addr, 2);
+  #if ARDUINO >= 100
+  t = wire -> read();
+  x = wire -> read();
+  #else
+  t = wire -> receive();
+  x = wire -> receive();
+  #endif
+  x <<= 8;
+  x |= t;
+  return x;
+}
+
+/**************************************************************************/
+/*!
+    Enables the device
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::enable(void)
+{
+  /* Enable the device by setting the control bit to 0x03 */
+  write8(TSL2561_COMMAND_BIT | TSL2561_REGISTER_CONTROL, TSL2561_CONTROL_POWERON);
+}
+
+/**************************************************************************/
+/*!
+    Disables the device (putting it in lower power sleep mode)
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::disable(void)
+{
+  /* Turn the device off to save power */
+  write8(TSL2561_COMMAND_BIT | TSL2561_REGISTER_CONTROL, TSL2561_CONTROL_POWEROFF);
+}
+
+/**************************************************************************/
+/*!
+    Private function to read luminosity on both channels
+*/
+/**************************************************************************/
+void Adafruit_TSL2561_Unified::getData (uint16_t *broadband, uint16_t *ir)
+{
+  /* Enable the device by setting the control bit to 0x03 */
+  enable();
+
+  /* Wait x ms for ADC to complete */
+  switch (_tsl2561IntegrationTime)
+  {
+    case TSL2561_INTEGRATIONTIME_13MS:
+      delay(TSL2561_DELAY_INTTIME_13MS);  // KTOWN: Was 14ms
+      break;
+    case TSL2561_INTEGRATIONTIME_101MS:
+      delay(TSL2561_DELAY_INTTIME_101MS); // KTOWN: Was 102ms
+      break;
+    default:
+      delay(TSL2561_DELAY_INTTIME_402MS); // KTOWN: Was 403ms
+      break;
+  }
+
+  /* Reads a two byte value from channel 0 (visible + infrared) */
+  *broadband = read16(TSL2561_COMMAND_BIT | TSL2561_WORD_BIT | TSL2561_REGISTER_CHAN0_LOW);
+
+  /* Reads a two byte value from channel 1 (infrared) */
+  *ir = read16(TSL2561_COMMAND_BIT | TSL2561_WORD_BIT | TSL2561_REGISTER_CHAN1_LOW);
+
+  // OUTPUT RAW MEASURED VALUES
+  DEBUGOUT.print(" *** TSL: Raw measurement data: chan0 = 0x"); DEBUGOUT.print(*broadband,HEX); DEBUGOUT.print(" / chan1 = 0x"); DEBUGOUT.println(*ir, HEX);
+
+  /* Turn the device off to save power */
+  if(_allowSleep) disable();
+}
 
 /*========================================================================*/
 /*                            CONSTRUCTORS                                */
@@ -47,12 +220,15 @@
 /**************************************************************************/
 /*!
     @brief Constructor
-    @param addr The I2C address this chip can be found on, 0x29, 0x39 or 0x49
-    @param sensorID An optional ID that will be placed in sensor events to help
-                    keep track if you have many sensors in use
+    @param addr The   I2C address this chip can be found on, 0x29, 0x39 or 0x49
+    @param sensorID   An optional ID that will be placed in sensor events to help
+                      keep track if you have many sensors in use
+    @param allowSleep When true, puts the device to sleep after every operation,
+                      to conserve power. Do not put the device to sleep if
+                      you are using interrupts, i.e. supply false here.
 */
 /**************************************************************************/
-Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID)
+Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID, bool allowSleep)
 {
   _addr = addr;
   _tsl2561Initialised = false;
@@ -60,6 +236,7 @@ Adafruit_TSL2561_Unified::Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorI
   _tsl2561IntegrationTime = TSL2561_INTEGRATIONTIME_13MS;
   _tsl2561Gain = TSL2561_GAIN_1X;
   _tsl2561SensorID = sensorID;
+  _allowSleep = allowSleep;
 }
 
 /*========================================================================*/
@@ -117,7 +294,7 @@ boolean Adafruit_TSL2561_Unified::init()
   setGain(_tsl2561Gain);
 
   /* Note: by default, the device is in power down mode on bootup */
-  disable();
+  if(_allowSleep) disable();
 
   return true;
 }
@@ -156,7 +333,7 @@ void Adafruit_TSL2561_Unified::setIntegrationTime(tsl2561IntegrationTime_t time)
   _tsl2561IntegrationTime = time;
 
   /* Turn the device off to save power */
-  disable();
+  if(_allowSleep) disable();
 }
 
 /**************************************************************************/
@@ -179,7 +356,7 @@ void Adafruit_TSL2561_Unified::setGain(tsl2561Gain_t gain)
   _tsl2561Gain = gain;
 
   /* Turn the device off to save power */
-  disable();
+  if(_allowSleep) disable();
 }
 
 /**************************************************************************/
@@ -272,64 +449,6 @@ void Adafruit_TSL2561_Unified::getLuminosity (uint16_t *broadband, uint16_t *ir)
       valid = true;
     }
   } while (!valid);
-}
-
-
-
-/**************************************************************************/
-/*!
-    Enables the device
-*/
-/**************************************************************************/
-void Adafruit_TSL2561_Unified::enable(void)
-{
-  /* Enable the device by setting the control bit to 0x03 */
-  write8(TSL2561_COMMAND_BIT | TSL2561_REGISTER_CONTROL, TSL2561_CONTROL_POWERON);
-}
-
-/**************************************************************************/
-/*!
-    Disables the device (putting it in lower power sleep mode)
-*/
-/**************************************************************************/
-void Adafruit_TSL2561_Unified::disable(void)
-{
-  /* Turn the device off to save power */
-  write8(TSL2561_COMMAND_BIT | TSL2561_REGISTER_CONTROL, TSL2561_CONTROL_POWEROFF);
-}
-
-/**************************************************************************/
-/*!
-    Private function to read luminosity on both channels
-*/
-/**************************************************************************/
-void Adafruit_TSL2561_Unified::getData (uint16_t *broadband, uint16_t *ir)
-{
-  /* Enable the device by setting the control bit to 0x03 */
-  enable();
-
-  /* Wait x ms for ADC to complete */
-  switch (_tsl2561IntegrationTime)
-  {
-    case TSL2561_INTEGRATIONTIME_13MS:
-      delay(TSL2561_DELAY_INTTIME_13MS);  // KTOWN: Was 14ms
-      break;
-    case TSL2561_INTEGRATIONTIME_101MS:
-      delay(TSL2561_DELAY_INTTIME_101MS); // KTOWN: Was 102ms
-      break;
-    default:
-      delay(TSL2561_DELAY_INTTIME_402MS); // KTOWN: Was 403ms
-      break;
-  }
-
-  /* Reads a two byte value from channel 0 (visible + infrared) */
-  *broadband = read16(TSL2561_COMMAND_BIT | TSL2561_WORD_BIT | TSL2561_REGISTER_CHAN0_LOW);
-
-  /* Reads a two byte value from channel 1 (infrared) */
-  *ir = read16(TSL2561_COMMAND_BIT | TSL2561_WORD_BIT | TSL2561_REGISTER_CHAN1_LOW);
-
-  /* Turn the device off to save power */
-  disable();
 }
 
 
@@ -514,62 +633,79 @@ void Adafruit_TSL2561_Unified::getSensor(sensor_t *sensor)
 }
 
 
+/**************************************************************************/
+/*!
+    @brief  Sets up interrupt control on the TSL2561
 
-/*========================================================================*/
-/*                          PRIVATE FUNCTIONS                             */
-/*========================================================================*/
+    Values for control & persist:
+      TSL2561_INTERRUPTCTL_DISABLE: interrupt output disabled
+      TSL2561_INTERRUPTCTL_LEVEL: use level interrupt, see setInterruptThreshold(),
+          datasheet calls this "traditional interrupt".
+      TSL2561_INTERRUPTCTL_SMBALERT: if you need this, you'll know what this means :).
+      TSL2561_INTERRUPTCTL_TEST: Sets interrupt and functions like SMBALERT mode.
+
+      intpersist = 0, every integration cycle generates an interrupt
+      intpersist = 1, any value outside of threshold generates an interrupt
+      intpersist = 2 to 15, value must be outside of threshold for 2 to 15 integration cycles
+
+      Note: A persist value of 0 causes an interrupt to occur after every integration cycle regardless
+      of the threshold settings. A value of 1 results in an interrupt after one integration
+      time period outside the threshold window. A value of N (where N is 2 through 15) results
+      in an interrupt only if the value remains outside the threshold window for N consecutive
+      integration cycles. For example, if N is equal to 10 and the integration time is 402 ms,
+      then the total time is approximately 4 seconds.
+
+*/
+/**************************************************************************/
+
+void Adafruit_TSL2561_Unified::setInterruptControl(tsl2561InterruptControl_t intcontrol, uint8_t intpersist) {
+  // Are we initialized?
+  if (!_tsl2561Initialised) begin();
+  /* Enable the device by setting the control bit to 0x03 */
+  enable();
+
+  uint8_t cmd = TSL2561_COMMAND_BIT | TSL2561_REGISTER_INTERRUPT;
+  uint8_t data = ((intcontrol & 0B00000011) << 4) | (intpersist & 0B00001111);
+
+  DEBUGOUT.print(" *** TSL2561: setInterruptControl, register = 0x"); DEBUGOUT.print(cmd, HEX); DEBUGOUT.print(" / data: 0x"); DEBUGOUT.println(data, HEX);
+
+  /* Update the interrupt control register */
+  write8(cmd, data);
+
+  /* Turn the device off to save power */
+  // NOTE: This disables interrupts so no good idea if you need them :)
+  if(_allowSleep) disable();
+}
+
+
+
+
+
+//
+// low, high: 16-bit threshold values
+// Returns true (1) if successful, false (0) if there was an I2C error
+// (Also see getError() below)
 
 /**************************************************************************/
 /*!
-    @brief  Writes a register and an 8 bit value over I2C
-    @param  reg I2C register to write the value to
-    @param  value The 8-bit value we're writing to the register
+    @brief  Set interrupt thresholds (TSL2561 supports only interrupts
+    generated by thresholds on channel 0)
 */
 /**************************************************************************/
-void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint8_t value)
-{
-  _i2c->beginTransmission(_addr);
-  _i2c->write(reg);
-  _i2c->write(value);
-  _i2c->endTransmission();
+
+void Adafruit_TSL2561_Unified::setInterruptThreshold(uint16_t lowThreshold, uint16_t highThreshold) {
+	// Write low and high threshold values
+	write16(TSL2561_COMMAND_BIT | TSL2561_REGISTER_THRESHHOLDL_LOW , lowThreshold);
+  write16(TSL2561_COMMAND_BIT | TSL2561_REGISTER_THRESHHOLDH_LOW , highThreshold);
 }
 
 /**************************************************************************/
 /*!
-    @brief  Reads an 8 bit value over I2C
-    @param  reg I2C register to read from
-    @returns 8-bit value containing single byte data read
+    @brief  Clears an active interrupt
 */
 /**************************************************************************/
-uint8_t Adafruit_TSL2561_Unified::read8(uint8_t reg)
-{
-  _i2c->beginTransmission(_addr);
-  _i2c->write(reg);
-  _i2c->endTransmission();
 
-  _i2c->requestFrom(_addr, 1);
-  return _i2c->read();
-}
-
-/**************************************************************************/
-/*!
-    @brief  Reads a 16 bit values over I2C
-    @param  reg I2C register to read from
-    @returns 16-bit value containing 2-byte data read
-*/
-/**************************************************************************/
-uint16_t Adafruit_TSL2561_Unified::read16(uint8_t reg)
-{
-  uint16_t x, t;
-
-  _i2c->beginTransmission(_addr);
-  _i2c->write(reg);
-  _i2c->endTransmission();
-
-  _i2c->requestFrom(_addr, 2);
-  t = _i2c->read();
-  x = _i2c->read();
-  x <<= 8;
-  x |= t;
-  return x;
+void Adafruit_TSL2561_Unified::clearLevelInterrupt(void) {
+	// Send command byte for interrupt clear
+  writereg8(TSL2561_COMMAND_BIT | TSL2561_CLEAR_BIT);
 }

--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -58,15 +58,15 @@
 /**************************************************************************/
 void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 {
-  wire -> beginTransmission(_addr);
+  _i2c-> beginTransmission(_addr);
   #if ARDUINO >= 100
-  wire -> write(reg);
-  wire -> write(value & 0xFF);
+  _i2c-> write(reg);
+  _i2c-> write(value & 0xFF);
   #else
-  wire -> send(reg);
-  wire -> send(value & 0xFF);
+  _i2c-> send(reg);
+  _i2c-> send(value & 0xFF);
   #endif
-  wire -> endTransmission();
+  _i2c-> endTransmission();
 }
 
 /**************************************************************************/
@@ -76,13 +76,13 @@ void Adafruit_TSL2561_Unified::write8 (uint8_t reg, uint32_t value)
 /**************************************************************************/
 void Adafruit_TSL2561_Unified::writereg8 (uint8_t reg)
 {
-  wire -> beginTransmission(_addr);
+  _i2c-> beginTransmission(_addr);
   #if ARDUINO >= 100
-  wire -> write(reg);
+  _i2c-> write(reg);
   #else
-  wire -> send(reg);
+  _i2c-> send(reg);
   #endif
-  wire -> endTransmission();
+  _i2c-> endTransmission();
 }
 
 /**************************************************************************/
@@ -106,19 +106,19 @@ void Adafruit_TSL2561_Unified::write16 (uint8_t reg, uint32_t value)
 /**************************************************************************/
 uint8_t Adafruit_TSL2561_Unified::read8(uint8_t reg)
 {
-  wire -> beginTransmission(_addr);
+  _i2c-> beginTransmission(_addr);
   #if ARDUINO >= 100
-  wire -> write(reg);
+  _i2c-> write(reg);
   #else
-  wire -> send(reg);
+  _i2c-> send(reg);
   #endif
-  wire -> endTransmission();
+  _i2c-> endTransmission();
 
-  wire -> requestFrom(_addr, 1);
+  _i2c-> requestFrom(_addr, 1);
   #if ARDUINO >= 100
-  return wire -> read();
+  return _i2c-> read();
   #else
-  return wire -> receive();
+  return _i2c-> receive();
   #endif
 }
 
@@ -131,21 +131,21 @@ uint16_t Adafruit_TSL2561_Unified::read16(uint8_t reg)
 {
   uint16_t x; uint16_t t;
 
-  wire -> beginTransmission(_addr);
+  _i2c-> beginTransmission(_addr);
   #if ARDUINO >= 100
-  wire -> write(reg);
+  _i2c-> write(reg);
   #else
-  wire -> send(reg);
+  _i2c-> send(reg);
   #endif
-  wire -> endTransmission();
+  _i2c-> endTransmission();
 
-  wire -> requestFrom(_addr, 2);
+  _i2c-> requestFrom(_addr, 2);
   #if ARDUINO >= 100
-  t = wire -> read();
-  x = wire -> read();
+  t = _i2c-> read();
+  x = _i2c-> read();
   #else
-  t = wire -> receive();
-  x = wire -> receive();
+  t = _i2c-> receive();
+  x = _i2c-> receive();
   #endif
   x <<= 8;
   x |= t;

--- a/Adafruit_TSL2561_U.h
+++ b/Adafruit_TSL2561_U.h
@@ -157,6 +157,11 @@
 #define TSL2561_DELAY_INTTIME_101MS   (120)   ///< Wait 120ms for 101ms integration
 #define TSL2561_DELAY_INTTIME_402MS   (450)   ///< Wait 450ms for 402ms integration
 
+// Approximations for Channel 1 to Channel 0 ratio for specific light conditions
+// -> See discussion near calculateRawCH0() function for details
+#define TSL2561_APPROXCHRATIO_SUN 0.325
+#define TSL2561_APPROXCHRATIO_LED 0.100
+
 /** TSL2561 I2C Registers */
 enum
 {
@@ -219,6 +224,7 @@ class Adafruit_TSL2561_Unified : public Adafruit_Sensor {
   void setGain(tsl2561Gain_t gain);
   void getLuminosity (uint16_t *broadband, uint16_t *ir);
   uint32_t calculateLux(uint16_t broadband, uint16_t ir);
+  uint32_t calculateRawCH0(uint16_t lux, float approxChRatio = TSL2561_APPROXCHRATIO_SUN);
 
   /* Unified Sensor API Functions */
   bool getEvent(sensors_event_t*);

--- a/Adafruit_TSL2561_U.h
+++ b/Adafruit_TSL2561_U.h
@@ -1,5 +1,6 @@
 /*!
  * @file Adafruit_TSL2561_U.h
+ * @author   K. Townsend (Adafruit Industries), T.Jacobs (CegekaLabs)
  *
  * This is part of Adafruit's FXOS8700 driver for the Arduino platform.  It is
  * designed specifically to work with the Adafruit FXOS8700 breakout:
@@ -16,12 +17,46 @@
  *
  * BSD license, all text here must be included in any redistribution.
  *
+ * @section LICENSE
+ *
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2013, Adafruit Industries
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  */
 
 #ifndef ADAFRUIT_TSL2561_H_
 #define ADAFRUIT_TSL2561_H_
 
-#include <Arduino.h>
+#if ARDUINO >= 100
+ #include <Arduino.h>
+#else
+ #include <WProgram.h>
+#endif
+
 #include <Adafruit_Sensor.h>
 #include <Wire.h>
 
@@ -35,7 +70,7 @@
 #define TSL2561_ADDR_HIGH         (0x49)    ///< Default address (pin pulled high)
 
 // Lux calculations differ slightly for CS package
-//#define TSL2561_PACKAGE_CS                ///< Chip scale package     
+//#define TSL2561_PACKAGE_CS                ///< Chip scale package
 #define TSL2561_PACKAGE_T_FN_CL             ///< Dual Flat No-Lead package
 
 #define TSL2561_COMMAND_BIT       (0x80)    ///< Must be 1
@@ -125,7 +160,7 @@
 /** TSL2561 I2C Registers */
 enum
 {
-  TSL2561_REGISTER_CONTROL          = 0x00, // Control/power register 
+  TSL2561_REGISTER_CONTROL          = 0x00, // Control/power register
   TSL2561_REGISTER_TIMING           = 0x01, // Set integration time register
   TSL2561_REGISTER_THRESHHOLDL_LOW  = 0x02, // Interrupt low threshold low-byte
   TSL2561_REGISTER_THRESHHOLDL_HIGH = 0x03, // Interrupt low threshold high-byte
@@ -157,47 +192,64 @@ typedef enum
 }
 tsl2561Gain_t;
 
-
+typedef enum
+{
+  TSL2561_INTERRUPTCTL_DISABLE         = 0x00,    // 0B00
+  TSL2561_INTERRUPTCTL_LEVEL           = 0x01,    // 0B01
+  TSL2561_INTERRUPTCTL_SMBALERT        = 0x02,    // 0B10
+  TSL2561_INTERRUPTCTL_TEST            = 0x03     // 0B11
+}
+tsl2561InterruptControl_t;
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Class that stores state and functions for interacting with TSL2561 Light Sensor
 */
 /**************************************************************************/
 class Adafruit_TSL2561_Unified : public Adafruit_Sensor {
  public:
-  Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID = -1);
+  Adafruit_TSL2561_Unified(uint8_t addr, int32_t sensorID = -1, bool allowSleep = true);
   boolean begin(void);
   boolean begin(TwoWire *theWire);
   boolean init();
-  
+
   /* TSL2561 Functions */
   void enableAutoRange(bool enable);
   void setIntegrationTime(tsl2561IntegrationTime_t time);
   void setGain(tsl2561Gain_t gain);
   void getLuminosity (uint16_t *broadband, uint16_t *ir);
   uint32_t calculateLux(uint16_t broadband, uint16_t ir);
-  
-  /* Unified Sensor API Functions */  
+
+  /* Unified Sensor API Functions */
   bool getEvent(sensors_event_t*);
   void getSensor(sensor_t*);
 
+  // Interrupt functions
+  void setInterruptControl(tsl2561InterruptControl_t intcontrol, uint8_t intpersist);
+  void setInterruptThreshold(uint16_t lowThreshold, uint16_t highThreshold);
+  void clearLevelInterrupt(void);
+
  private:
   TwoWire *_i2c;
- 
+
   int8_t _addr;
   boolean _tsl2561Initialised;
   boolean _tsl2561AutoGain;
   tsl2561IntegrationTime_t _tsl2561IntegrationTime;
   tsl2561Gain_t _tsl2561Gain;
   int32_t _tsl2561SensorID;
-  
+  boolean _allowSleep;
+
   void     enable (void);
   void     disable (void);
-  void     write8 (uint8_t reg, uint8_t value);
+  void     write8 (uint8_t reg, uint32_t value);
+  void     writereg8 (uint8_t reg);
+  void     write16 (uint8_t reg, uint32_t value);
   uint8_t  read8 (uint8_t reg);
   uint16_t read16 (uint8_t reg);
   void     getData (uint16_t *broadband, uint16_t *ir);
+
+
 };
 
 #endif // ADAFRUIT_TSL2561_H

--- a/README.md
+++ b/README.md
@@ -29,22 +29,19 @@ One of the big advantages of the TSL2561 is that it is capable of measuring both
 
 More information on the TSL2561 can be found in the datasheet: http://www.adafruit.com/datasheets/TSL2561.pdf
 
-## What is the Adafruit Unified Sensor Library? ##
+## Interrupt support ##
 
-The Adafruit Unified Sensor Library (Adafruit_Sensor) provides a common interface and data type for any supported sensor.  It defines some basic information about the sensor (sensor limits, etc.), and returns standard SI units of a specific type and scale for each supported sensor type.
+The TSL2561 can trigger an external interrupt on your MCU by connecting the "INT" pin of the Adafruit breakout to an external-interrupt capable pin on your microcontroller. The INT signal is active low.
 
-It provides a simple abstraction layer between your application and the actual sensor HW, allowing you to drop in any comparable sensor with only one or two lines of code to change in your project (essentially the constructor since the functions to read sensor data and get information about the sensor are defined in the base Adafruit_Sensor class).
+A challenge is determining appropriate values for configuring the interrupt. The TSL2561 only supports threshold detection on it's broad spectrum (channel 0) sensor. Unfortunately, the calculation to get the amount of "lux" (the prefered SI unit), involves the ratio of the values of channel 0 (broadband spectrum) and channel 1 (IR spectrum). Given that you only can set a threshold for channel 0, converting a lux threshold to a channel 0 value will require an estimation for channel 1.
 
-This is imporant useful for two reasons:
+You can use the calculateRawCH0() function to take a threshold value in lux and provide an educated guess for what the channel 0 value might be. A custom approximation for the channel 1/channel 0 ratio can be provided if needed; by default is uses an estimation that is correct for sunlight detected at noon. Deviations of this approximation (and hence of the interrupt being triggered incorrectly) are known for light sources that have a different IR (channel 1) light emission, e.g. LED light sources.
 
-1.) You can use the data right away because it's already converted to SI units that you understand and can compare, rather than meaningless values like 0..1023.
+The best approach is to take an educated guess at the channel 0 sensor value given a lux threshold using the calculateRawCH0() function. The value returned by this function can be considered a good reference value. However, always be sure to check in your code (using the calculateLux() function) whether your desired lux threshold value was actually exceeded! In other words: be ready to handle interrupts being triggered incorrectly.
 
-2.) Because SI units are standardised in the sensor library, you can also do quick sanity checks working with new sensors, or drop in any comparable sensor if you need better sensitivity or if a lower cost unit becomes available, etc. 
-
-Light sensors will always report units in lux, gyroscopes will always report units in rad/s, etc. ... freeing you up to focus on the data, rather than digging through the datasheet to understand what the sensor's raw numbers really mean.
+AFAIK, due to the fact that you can only set channel 0 thresholds, there is no workaround for this "guestimation" protocol for using interrupts with the TSL2561. If you need a lux-based threshold definition, you might want to consider other light sensors.
 
 ## About this Driver ##
 
-Adafruit invests time and resources providing this open source code.  Please support Adafruit and open-source hardware by purchasing products from Adafruit!
-
 Written by Kevin (KTOWN) Townsend for Adafruit Industries.
+Additions for interrupt support by Tim Jacobs in 2017.

--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ Light sensors will always report units in lux, gyroscopes will always report uni
 
 ## About this Driver ##
 
+Adafruit invests time and resources providing this open source code.  Please support Adafruit and open-source hardware by purchasing products from Adafruit!
+
 Written by Kevin (KTOWN) Townsend for Adafruit Industries.
 Additions for interrupt support by Tim Jacobs in 2017.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ The best approach is to take an educated guess at the channel 0 sensor value giv
 
 AFAIK, due to the fact that you can only set channel 0 thresholds, there is no workaround for this "guestimation" protocol for using interrupts with the TSL2561. If you need a lux-based threshold definition, you might want to consider other light sensors.
 
+## What is the Adafruit Unified Sensor Library? ##
+
+The Adafruit Unified Sensor Library (Adafruit_Sensor) provides a common interface and data type for any supported sensor.  It defines some basic information about the sensor (sensor limits, etc.), and returns standard SI units of a specific type and scale for each supported sensor type.
+
+It provides a simple abstraction layer between your application and the actual sensor HW, allowing you to drop in any comparable sensor with only one or two lines of code to change in your project (essentially the constructor since the functions to read sensor data and get information about the sensor are defined in the base Adafruit_Sensor class).
+
+This is imporant useful for two reasons:
+
+1.) You can use the data right away because it's already converted to SI units that you understand and can compare, rather than meaningless values like 0..1023.
+
+2.) Because SI units are standardised in the sensor library, you can also do quick sanity checks working with new sensors, or drop in any comparable sensor if you need better sensitivity or if a lower cost unit becomes available, etc.
+
+Light sensors will always report units in lux, gyroscopes will always report units in rad/s, etc. ... freeing you up to focus on the data, rather than digging through the datasheet to understand what the sensor's raw numbers really mean.
+
 ## About this Driver ##
 
 Written by Kevin (KTOWN) Townsend for Adafruit Industries.

--- a/examples/interrupts/interrupts.ino
+++ b/examples/interrupts/interrupts.ino
@@ -1,0 +1,169 @@
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include <Adafruit_TSL2561_U.h>
+
+/* This driver uses the Adafruit unified sensor library (Adafruit_Sensor),
+   which provides a common 'type' for sensor data and some helper functions.
+
+   To use this driver you will also need to download the Adafruit_Sensor
+   library and include it in your libraries folder.
+
+   You should also assign a unique ID to this sensor for use with
+   the Adafruit Sensor API so that you can identify this particular
+   sensor in any data logs, etc.  To assign a unique ID, simply
+   provide an appropriate value in the constructor below (12345
+   is used by default in this example).
+
+   Connections
+   ===========
+   Connect SCL to analog 5
+   Connect SDA to analog 4
+   Connect VDD to 3.3V DC
+   Connect GROUND to common ground
+
+   I2C Address
+   ===========
+   The address will be different depending on whether you leave
+   the ADDR pin floating (addr 0x39), or tie it to ground or vcc.
+   The default addess is 0x39, which assumes the ADDR pin is floating
+   (not connected to anything).  If you set the ADDR pin high
+   or low, use TSL2561_ADDR_HIGH (0x49) or TSL2561_ADDR_LOW
+   (0x29) respectively.
+
+   History
+   =======
+   2013/JAN/31  - First version (KTOWN)
+*/
+
+Adafruit_TSL2561_Unified tsl = Adafruit_TSL2561_Unified(TSL2561_ADDR_FLOAT, 12345);
+
+// We assume the Adafruit TSL2561's "int" pin is attached to this digital pin
+#define INTERRUPT_PIN 0
+
+/**************************************************************************/
+/*
+    Displays some basic information on this sensor from the unified
+    sensor API sensor_t type (see Adafruit_Sensor for more information)
+*/
+/**************************************************************************/
+void displaySensorDetails(void)
+{
+  sensor_t sensor;
+  tsl.getSensor(&sensor);
+  Serial.println("------------------------------------");
+  Serial.print  ("Sensor:       "); Serial.println(sensor.name);
+  Serial.print  ("Driver Ver:   "); Serial.println(sensor.version);
+  Serial.print  ("Unique ID:    "); Serial.println(sensor.sensor_id);
+  Serial.print  ("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" lux");
+  Serial.print  ("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" lux");
+  Serial.print  ("Resolution:   "); Serial.print(sensor.resolution); Serial.println(" lux");
+  Serial.println("------------------------------------");
+  Serial.println("");
+  delay(500);
+}
+
+/**************************************************************************/
+/*
+    Configures the gain and integration time for the TSL2561
+*/
+/**************************************************************************/
+void configureSensor(void)
+{
+  /* You can also manually set the gain or enable auto-gain support */
+  // tsl.setGain(TSL2561_GAIN_1X);      /* No gain ... use in bright light to avoid sensor saturation */
+  // tsl.setGain(TSL2561_GAIN_16X);     /* 16x gain ... use in low light to boost sensitivity */
+  tsl.enableAutoRange(true);            /* Auto-gain ... switches automatically between 1x and 16x */
+
+  /* Changing the integration time gives you better sensor resolution (402ms = 16-bit data) */
+  tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_13MS);      /* fast but low resolution */
+  // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_101MS);  /* medium resolution and speed   */
+  // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_402MS);  /* 16-bit data but slowest conversions */
+
+  /* Configure interrupt thresholds
+     Note: value in raw sensor units, BEFORE being calculated to lux...
+     Calculating a given lux value to a sensor threshold value is left
+     as an exercise for the reader :) */
+  tsl.setInterruptThreshold(0,3000);
+  /* Enable level interrupt, trigger interrupt after 5 integration times
+     -> Because integration time is 13ms by default, this means the threshold
+        needs to be exceeded for more than 65ms before the interrupt is triggered.
+        Maximum value is 15; put to 1 for immediate triggering; put to 0 to have
+        the interrupt triggered after every integration time (regardless of whether
+        the thresholds were exceeded or not)
+  */
+  tsl.setInterruptControl(TSL2561_INTERRUPTCTL_LEVEL, 5);
+  tsl.clearLevelInterrupt();
+
+  /* Update these values depending on what you've set above! */
+  Serial.println("------------------------------------");
+  Serial.print  ("Gain:         "); Serial.println("Auto");
+  Serial.print  ("Timing:       "); Serial.println("13 ms");
+  Serial.println("------------------------------------");
+}
+
+/**************************************************************************/
+/*
+    Arduino setup function (automatically called at startup)
+*/
+/**************************************************************************/
+void setup(void)
+{
+  Serial.begin(9600);
+  Serial.println("Light Sensor Test"); Serial.println("");
+
+  /* Configure the interrupt pin as input pin */
+  pinMode(INTERRUPT_PIN, INPUT_PULLUP);
+
+  /* Initialise the sensor */
+  //use tsl.begin() to default to Wire,
+  //tsl.begin(&Wire2) directs api to use Wire2, etc.
+  if(!tsl.begin())
+  {
+    /* There was a problem detecting the TSL2561 ... check your connections */
+    Serial.print("Ooops, no TSL2561 detected ... Check your wiring or I2C ADDR!");
+    while(1);
+  }
+
+  /* Display some basic information on this sensor */
+  displaySensorDetails();
+
+  /* Setup the sensor gain and integration time */
+  configureSensor();
+
+  /* We're ready to go! */
+  Serial.println("");
+}
+
+/**************************************************************************/
+/*
+    Arduino loop function, called once 'setup' is complete (your own code
+    should go here)
+*/
+/**************************************************************************/
+void loop(void)
+{
+  /* Interrupt triggered? */
+  if(digitalRead(INTERRUPT_PIN) == LOW) {
+    // We have an interrupt!
+    Serial.println("TSL2561 reported interrupt thresholds exceeded!");
+    // Clear interrupt on sensor
+    tsl.clearLevelInterrupt();
+  }
+
+  /* Get a new sensor event */
+  sensors_event_t event;
+  tsl.getEvent(&event);
+
+  /* Display the results (light is measured in lux) */
+  if (event.light)
+  {
+    Serial.print(event.light); Serial.println(" lux");
+  }
+  else
+  {
+    /* If event.light = 0 lux the sensor is probably saturated
+       and no reliable data could be generated! */
+    Serial.println("Sensor overload");
+  }
+  delay(250);
+}

--- a/examples/interrupts/interrupts.ino
+++ b/examples/interrupts/interrupts.ino
@@ -79,11 +79,12 @@ void configureSensor(void)
   // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_101MS);  /* medium resolution and speed   */
   // tsl.setIntegrationTime(TSL2561_INTEGRATIONTIME_402MS);  /* 16-bit data but slowest conversions */
 
-  /* Configure interrupt thresholds
-     Note: value in raw sensor units, BEFORE being calculated to lux...
-     Calculating a given lux value to a sensor threshold value is left
-     as an exercise for the reader :) */
-  tsl.setInterruptThreshold(0,3000);
+  /* Configure interrupt thresholds */
+  // First: convert lux value to raw sensor value, using "sunlight" approximation.
+  // Other approximations, see Adafruit_TSL2561_U.h
+  uint32_t threshold = tsl.calculateRawCH0(3000, TSL2561_APPROXCHRATIO_SUN);
+  tsl.setInterruptThreshold(0,threshold);
+
   /* Enable level interrupt, trigger interrupt after 5 integration times
      -> Because integration time is 13ms by default, this means the threshold
         needs to be exceeded for more than 65ms before the interrupt is triggered.

--- a/examples/interrupts/interrupts.ino
+++ b/examples/interrupts/interrupts.ino
@@ -39,6 +39,7 @@ Adafruit_TSL2561_Unified tsl = Adafruit_TSL2561_Unified(TSL2561_ADDR_FLOAT, 1234
 
 // We assume the Adafruit TSL2561's "int" pin is attached to this digital pin
 #define INTERRUPT_PIN 0
+#define THRESHOLD     3000
 
 /**************************************************************************/
 /*
@@ -82,7 +83,7 @@ void configureSensor(void)
   /* Configure interrupt thresholds */
   // First: convert lux value to raw sensor value, using "sunlight" approximation.
   // Other approximations, see Adafruit_TSL2561_U.h
-  uint32_t threshold = tsl.calculateRawCH0(3000, TSL2561_APPROXCHRATIO_SUN);
+  uint32_t threshold = tsl.calculateRawCH0(THRESHOLD, TSL2561_APPROXCHRATIO_SUN);
   tsl.setInterruptThreshold(0,threshold);
 
   /* Enable level interrupt, trigger interrupt after 5 integration times
@@ -99,6 +100,7 @@ void configureSensor(void)
   Serial.println("------------------------------------");
   Serial.print  ("Gain:         "); Serial.println("Auto");
   Serial.print  ("Timing:       "); Serial.println("13 ms");
+  Serial.print  ("Threshold     "); Serial.print(THRESHOLD); Serial.println(" lux");
   Serial.println("------------------------------------");
 }
 


### PR DESCRIPTION
These changes add support for configuring level interrupts, supported by the TSL2561 luminosity sensor. Some important notes:

    Interrupts can be enabled using the setInterruptThreshold and setInterruptControl functions.
    Thresholds need to be configured in TSL2561 "native" units, and not in SI Lux units! I included a function called calculateRawCH0 to estimate what "raw" or "native sensor" threshold value corresponds to what lux threshold value.
    Example on using interrupts included

Improper clearing of interrupts leads to the TSL2561 to hang. Therefore, exercise caution when implementing interrupt code in your sketches.

Limitations:

    Only tested on SAMD21 platform (Arduino Zero/MKR1000/MKR1200/Feather M0/...)
    Example sketch not thoroughly tested ;).

Disclaimer:
    I merely got rid of the merge conflicts with the original pull request so it could be incorporated into this library. I did NOT thoroughly test this library and am just assuming that it does work since it doesn't look like there have been a lot of issues with it since the original pull request!
    The original request can be found [here](https://github.com/adafruit/Adafruit_TSL2561/pull/10#issue-142327478)