### PR TITLE
Fix warning "comparison of unsigned expression >= 0 is always true" on ESP32

### DIFF
--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -407,7 +407,7 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
   unsigned int b, m;
 
 #ifdef TSL2561_PACKAGE_CS
-  if ((ratio >= 0) && (ratio <= TSL2561_LUX_K1C))
+  if (ratio <= TSL2561_LUX_K1C)
     {b=TSL2561_LUX_B1C; m=TSL2561_LUX_M1C;}
   else if (ratio <= TSL2561_LUX_K2C)
     {b=TSL2561_LUX_B2C; m=TSL2561_LUX_M2C;}

--- a/Adafruit_TSL2561_U.cpp
+++ b/Adafruit_TSL2561_U.cpp
@@ -424,7 +424,7 @@ uint32_t Adafruit_TSL2561_Unified::calculateLux(uint16_t broadband, uint16_t ir)
   else if (ratio > TSL2561_LUX_K8C)
     {b=TSL2561_LUX_B8C; m=TSL2561_LUX_M8C;}
 #else
-  if ((ratio >= 0) && (ratio <= TSL2561_LUX_K1T))
+  if (ratio <= TSL2561_LUX_K1T)
     {b=TSL2561_LUX_B1T; m=TSL2561_LUX_M1T;}
   else if (ratio <= TSL2561_LUX_K2T)
     {b=TSL2561_LUX_B2T; m=TSL2561_LUX_M2T;}


### PR DESCRIPTION
I removed the check if the variable 'ratio' is greater than zero because it is unsigned and therefore always greater than zero.

The esp32 compiler gives me: "warning: comparison of unsigned expression >= 0 is always true". I'm using parts of this code on esp32 using the esp-idf, not arduino, in a plain C environment. I don't have any issues with type 'unsigned long' so I don't think that a change to an unsigned type is needed. Especially as this code is from the datasheet of the tsl2561.